### PR TITLE
Fix bug where object with protected class attributes and public getters and setters is not being converted.

### DIFF
--- a/raelgc/view/Template.php
+++ b/raelgc/view/Template.php
@@ -408,12 +408,12 @@ namespace raelgc\view {
 						for($i = 1; $i < sizeof($property); $i++){
 							if(!is_null($pointer)){
 								$obj = strtolower(str_replace('_', '', $property[$i]));
-								// Property acessor
-								if(property_exists($pointer, $obj)) $pointer = $pointer->$obj;
 								// Get accessor
-								elseif(method_exists($pointer, "get$obj")) $pointer = $pointer->{"get$obj"}();
+								if(method_exists($pointer, "get$obj")) $pointer = $pointer->{"get$obj"}();
 								// Magic __get accessor
 								elseif(method_exists($pointer, "__get")) $pointer = $pointer->__get($property[$i]);
+								// Property acessor
+								elseif(property_exists($pointer, $obj)) $pointer = $pointer->$obj;
 								else {
 									$className = $property[$i-1] ? $property[$i-1] : get_class($instance);
 									$class = is_null($pointer) ? "NULL" : get_class($pointer);


### PR DESCRIPTION
Whenever trying to read an object from an ORM, such as Doctrine, and protected attributes are used, the reading of their values fails, throwing an error. This is because the method property_exists is called, within the protected method subst, and it throws an error because it finds no public attributes. To avoid this issue, since public getters and setters are required when using protected class attributes, the first type of elements to be read should be public methods. This avoids this issue and that is what this patch does.
