### PR TITLE
Removing useless code, including deprecated `each`  call (#35)

### DIFF
--- a/raelgc/view/Template.php
+++ b/raelgc/view/Template.php
@@ -15,7 +15,7 @@ namespace raelgc\view {
 	 * minor features.
 	 *
 	 * @author Rael G.C. (rael.gc@gmail.com)
-	 * @version 2.2.7
+	 * @version 2.2.8
 	 */
 	class Template {
 
@@ -129,6 +129,8 @@ namespace raelgc\view {
 				if(!isset($this->properties[$varname])) $this->properties[$varname] = array();
 				if(method_exists($value, "__toString")) $stringValue = $value->__toString();
 				else $stringValue = "Object";
+			} elseif (is_array($value)) {
+				$stringValue = implode(', ', $value);
 			}
 			$this->setValue($varname, $stringValue);
 			return $value;
@@ -430,22 +432,8 @@ namespace raelgc\view {
 								$pointer = $instance->get($obj);
 							}
 						}
-						// Checking if final value is an object...
-						if(is_object($pointer)){
-							$pointer_str = method_exists($pointer, "__toString") ? $pointer->__toString() : json_encode($pointer);
-						// ... or an array
-						} elseif(is_array($pointer)){
-							$value = "";
-							for($i=0; list($key, $val) = each($pointer); $i++){
-								$value.= "$key => $val";
-								if($i<sizeof($pointer)-1) $value.= ",";
-							}
-							$pointer_str = $value;
-						} else {
-							$pointer_str = $pointer;
-						}
 						// Replacing value
-						$s = str_replace("{".$var.$properties."}", $pointer_str, $s);
+						$s = str_replace("{".$var.$properties."}", $pointer, $s);
 						// Object with modifiers
 						if(isset($this->modifiers[$var.$properties])){
 							foreach($this->modifiers[$var.$properties] as $exp){

--- a/raelgc/view/Template.php
+++ b/raelgc/view/Template.php
@@ -128,7 +128,7 @@ namespace raelgc\view {
 				$this->instances[$varname] = $value;
 				if(!isset($this->properties[$varname])) $this->properties[$varname] = array();
 				if(method_exists($value, "__toString")) $stringValue = $value->__toString();
-				else $stringValue = "Object";
+				else $stringValue = 'Object: '.json_encode($value);
 			} elseif (is_array($value)) {
 				$stringValue = implode(', ', $value);
 			}

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -161,6 +161,13 @@ final class TemplateTest extends TestCase
 		$this->assertEquals('foobar', trim($tpl->parse()));
 	}
 
+	public function testArrayParse()
+	{
+		$tpl = new Template(__DIR__ . '/simple_var.html');
+		$foo = ['bar', 'baz', 'qux'];
+		$tpl->FOO = $foo;
+		$this->assertEquals('bar, baz, qux', trim($tpl->parse()));
+	}
 
 	public function testObjectParse()
 	{

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -179,7 +179,7 @@ final class TemplateTest extends TestCase
 		};
 		$foo->setBar('foobar');
 		$tpl->FOO = $foo;
-		$this->assertEquals('Object', trim($tpl->parse()));
+		$this->assertEquals('Object: {"bar":"foobar"}', trim($tpl->parse()));
 	}
 
 	public function testFailureSimpleObjectCaseMismatch()


### PR DESCRIPTION
Removed code was unreachable.

Fixes #35.